### PR TITLE
fix typo invest ELYFI

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -12,7 +12,7 @@
       "description": "ELYSIA is a project that makes real-world assets into tokens and connects them with the blockchain."
     },
     "main": {
-      "CTAButton": ["Invest to ELYFI"],
+      "CTAButton": ["Invest in ELYFI"],
       "top": [
         "ELYSIA PROTOCOL",
         "Real world asset tokenization DAO.",


### PR DESCRIPTION
#### 관련 이슈

#### 변경 사항 및 이유 
Invest to ELYFI 라는 표현을 Invest in ELYFI로 수정했습니다.
해당 브랜치에서는 그 외 다른 변경사항은 없습니다.

#### PR Point

#### 참고 사항
